### PR TITLE
Specifiy cardinal & rotational directions for COG & heading

### DIFF
--- a/msg/Contact.msg
+++ b/msg/Contact.msg
@@ -13,9 +13,9 @@ string name
 string callsign
 
 geographic_msgs/GeoPoint position
-float32 cog                     # Course over ground (radians) [-1 = unavailable]
+float32 cog                     # Course over ground (radians clockwise from north) [-1 = unavailable]
 float32 sog                     # Speed over ground (m/s) [-1 = unavailable]
-float32 heading                 # True heading (radians) [-1 = unavailable]
+float32 heading                 # True heading (radians clockwise from north) [-1 = unavailable]
 
 float32 dimension_to_stbd       # Distance between position source and starboard end of the contact (m) [0 = unavailable]
 float32 dimension_to_port       # Distance between position source and port end of the contact (m) [0 = unavailable]


### PR DESCRIPTION
I believe both `cog` and  `heading` are clockwise from north, since that's how they're encoded [here](https://github.com/afb2001/path_planner/blob/master/path_planner_common/include/path_planner_common/State.h), and [this](https://github.com/afb2001/path_planner/blob/59da871fa0af7e6c86cb6e78a9419683a04ae4ba/path_planner/src/path_planner_node.cpp#L141) maps `marine_msgs::Contact.cog` directly to `State.heading` without any transformation.

Is this correct? If so, just adding little notes to make explicit.